### PR TITLE
adding Domain webhook functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ EXPOSE 5000
 ENV CLIENT_ID=${CLIENT_ID}
 ENV CLIENT_SECRET=${CLIENT_SECRET}
 # adding port did not change anything 
-ENV REDIRECT_URI=localhost:8042/exchange_token
+ENV REDIRECT_URI=strava.schaetz.cz/exchange_token
 
 CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ app = Flask(__name__, template_folder='/app/templates')
 # Constants for Strava API integration
 CLIENT_ID = "155612"  # Replace with your actual Strava Client ID
 CLIENT_SECRET = "7cd0b1dd7c81c3755da428082a3228182542886b"  # Replace with your actual Strava Client Secret
-REDIRECT_URI = "http://strava.schaetz.cz/exchange_token"  # Redirect URI for OAuth
+REDIRECT_URI = "https://strava.schaetz.cz/exchange_token"  # Redirect URI for OAuth
 TOKEN_URL = "https://www.strava.com/oauth/token"  # URL to exchange authorization code for tokens
 ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"  # URL to fetch activities
 WEBHOOK_SUBSCRIPTION_URL = "https://www.strava.com/api/v3/push_subscriptions"  # URL for webhook subscription

--- a/app.py
+++ b/app.py
@@ -283,6 +283,12 @@ def exchange_token_handler():
 
 
 if __name__ == '__main__':
+    # Run the Flask application
+    app.run(debug=True, port=5000, host='0.0.0.0')
+    
+    # Wait for 2 seconds after starting the app
+    time.sleep(2)
+
     # Call the subscription function at the start of the app
     try:
         subscription_id = subscribe_to_webhook()
@@ -290,13 +296,10 @@ if __name__ == '__main__':
         print(f"Error subscribing to webhook: {e}")
         subscription_id = None
 
-    try:
-        # Run the Flask application
-        app.run(debug=True, port=5000, host='0.0.0.0')
-    finally:
-        # Unsubscribe from the webhook when the app is stopped
-        if subscription_id:
-            try:
-                unsubscribe_from_webhook(subscription_id)
-            except Exception as e:
-                print(f"Error unsubscribing from webhook: {e}")
+
+    # Unsubscribe from the webhook when the app is stopped
+    if subscription_id:
+        try:
+            unsubscribe_from_webhook(subscription_id)
+        except Exception as e:
+            print(f"Error unsubscribing from webhook: {e}")

--- a/app.py
+++ b/app.py
@@ -104,7 +104,7 @@ def delayed_unsubscription():
                 unsubscribe_from_webhook(subscription_id)
     threading.Thread(target=task).start()
 
-@app.before_first_request
+@app.before_request
 def initialize_subscription():
     logging.debug("Entering initialize_subscription function.")
     global initialized
@@ -112,11 +112,6 @@ def initialize_subscription():
         initialized = True
         logging.info("Initializing webhook subscription.")
         delayed_subscription()
-
-@app.before_shutdown
-def cleanup_subscription():
-    logging.debug("Entering cleanup_subscription function.")
-    delayed_unsubscription()
 
 @app.route('/unsubscribe', methods=['POST'])
 def manual_unsubscribe():

--- a/app.py
+++ b/app.py
@@ -40,8 +40,10 @@ def subscribe_to_webhook():
         else:
             print(f"❌ Failed to subscribe to the webhook. Status code: {response.status_code}")
             print(response.text)
+            return None
     except requests.exceptions.RequestException as e:
         print(f"An error occurred during webhook subscription: {e}")
+        return None
 
 def unsubscribe_from_webhook(subscription_id):
     """
@@ -51,12 +53,14 @@ def unsubscribe_from_webhook(subscription_id):
         subscription_id (str): The ID of the subscription to be deleted.
     """
     try:
-        response = requests.delete(
-            f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}",
-            params={'client_id': CLIENT_ID, 'client_secret': CLIENT_SECRET}
-        )
+        url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
+        params = {
+            'client_id': CLIENT_ID,
+            'client_secret': CLIENT_SECRET
+        }
+        response = requests.delete(url, params=params)
         if response.status_code == 204:
-            print("✅ Successfully unsubscribed from the webhook.")
+            print(f"✅ Successfully unsubscribed from the webhook. Subscription ID: {subscription_id}")
         else:
             print(f"❌ Failed to unsubscribe from the webhook. Status code: {response.status_code}")
             print(response.text)
@@ -234,8 +238,6 @@ def exchange_token_handler():
     Returns:
         Response: HTML response with the result of the token exchange and activity processing.
     """
-    # Call the subscription function at the start of the app
-    # subscription_id = subscribe_to_webhook()
 
     if request.method == 'GET' and 'hub.challenge' in request.args:
         # Handle callback validation

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ CALLBACK_URL = "https://strava.schaetz.cz/exchange_token"  # Callback URL for we
 VERIFY_TOKEN = "STRAVA"  # Token to verify webhook requests
 
 subscription_id = None
+initialized = False
 
 def subscribe_to_webhook():
     """
@@ -242,9 +243,12 @@ def delayed_subscription():
         print(f"Error subscribing to webhook: {e}")
         subscription_id = None
 
-@app.before_first_request
+@app.before_request
 def initialize_subscription():
-    threading.Thread(target=delayed_subscription).start()
+    global initialized
+    if not initialized:
+        initialized = True
+        threading.Thread(target=delayed_subscription).start()
 
 @app.teardown_appcontext
 def cleanup_subscription(exception=None):
@@ -269,6 +273,7 @@ def exchange_token_handler():
             return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200
         else:
             return jsonify({'error': 'Invalid verify token'}), 403
+    # return "Exchange token endpoint"
 
     # Handle token exchange and data processing
     authorization_code = request.args.get('code')

--- a/app.py
+++ b/app.py
@@ -235,7 +235,7 @@ def exchange_token_handler():
         Response: HTML response with the result of the token exchange and activity processing.
     """
     # Call the subscription function at the start of the app
-    subscription_id = subscribe_to_webhook()
+    # subscription_id = subscribe_to_webhook()
 
     if request.method == 'GET' and 'hub.challenge' in request.args:
         # Handle callback validation
@@ -271,15 +271,30 @@ def exchange_token_handler():
                                    scope=scope,
                                    elevation_summary=elevation_summary)
         else:
-            unsubscribe_from_webhook(subscription_id)
+            # unsubscribe_from_webhook(subscription_id)
             return render_template('error.html', error="Failed to exchange authorization code.")
     else:
-        unsubscribe_from_webhook(subscription_id)
+        # unsubscribe_from_webhook(subscription_id)
         error = request.args.get('error')
         return render_template('error.html', error=f"Authorization failed: {error}")
 
 
 
 if __name__ == '__main__':
-    # Run the Flask application
-    app.run(debug=True, port=5000, host='0.0.0.0')
+    # Call the subscription function at the start of the app
+    try:
+        subscription_id = subscribe_to_webhook()
+    except Exception as e:
+        print(f"Error subscribing to webhook: {e}")
+        subscription_id = None
+
+    try:
+        # Run the Flask application
+        app.run(debug=True, port=5000, host='0.0.0.0')
+    finally:
+        # Unsubscribe from the webhook when the app is stopped
+        if subscription_id:
+            try:
+                unsubscribe_from_webhook(subscription_id)
+            except Exception as e:
+                print(f"Error unsubscribing from webhook: {e}")

--- a/app.py
+++ b/app.py
@@ -5,7 +5,14 @@ import time
 import logging
 
 # Configure logging
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler("app.log", mode="a")
+    ]
+)
 
 # Initialize the Flask application
 app = Flask(__name__)
@@ -19,60 +26,109 @@ WEBHOOK_SUBSCRIPTION_URL = "https://www.strava.com/api/v3/push_subscriptions"
 
 subscription_id = None
 initialized = False
+lock = threading.Lock()
 
 def subscribe_to_webhook():
+    global subscription_id
+    logging.debug("Entering subscribe_to_webhook function.")
     payload = {
         'client_id': CLIENT_ID,
         'client_secret': CLIENT_SECRET,
         'callback_url': CALLBACK_URL,
         'verify_token': VERIFY_TOKEN
     }
-    response = requests.post(WEBHOOK_SUBSCRIPTION_URL, data=payload)
-    if response.status_code == 201:
-        return response.json().get("id")
-    return None
+    logging.info(f"Payload for webhook subscription: {payload}")
+    try:
+        response = requests.post(WEBHOOK_SUBSCRIPTION_URL, data=payload)
+        logging.debug(f"Webhook subscription response: {response.status_code} - {response.text}")
+        if response.status_code == 201:
+            with lock:
+                subscription_id = response.json().get("id")
+            logging.info(f"✅ Successfully subscribed to the webhook. Subscription ID: {subscription_id}")
+            return subscription_id
+        else:
+            logging.error(f"❌ Failed to subscribe to the webhook. Status code: {response.status_code}")
+            logging.error(f"Response body: {response.text}")
+            return None
+    except requests.exceptions.RequestException as e:
+        logging.exception("An error occurred during webhook subscription.")
+        return None
 
 def unsubscribe_from_webhook(subscription_id):
-    url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
-    params = {
-        'client_id': CLIENT_ID,
-        'client_secret': CLIENT_SECRET
-    }
-    requests.delete(url, params=params)
+    logging.debug("Entering unsubscribe_from_webhook function.")
+    logging.info(f"Attempting to unsubscribe from webhook with Subscription ID: {subscription_id}")
+    try:
+        url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
+        params = {
+            'client_id': CLIENT_ID,
+            'client_secret': CLIENT_SECRET
+        }
+        logging.debug(f"Unsubscription URL: {url}, Params: {params}")
+        response = requests.delete(url, params=params)
+        logging.debug(f"Webhook unsubscription response: {response.status_code} - {response.text}")
+        if response.status_code == 204:
+            logging.info(f"✅ Successfully unsubscribed from the webhook. Subscription ID: {subscription_id}")
+        else:
+            logging.error(f"❌ Failed to unsubscribe from the webhook. Status code: {response.status_code}, Subscription ID: {subscription_id}")
+            logging.error(f"Response body: {response.text}")
+    except requests.exceptions.RequestException as e:
+        logging.exception("An error occurred during webhook unsubscription.")
 
 def delayed_subscription():
+    logging.debug("Entering delayed_subscription function.")
     def task():
-        time.sleep(5)  # Wait for 5 seconds before subscribing
+        time.sleep(5)
         global subscription_id
-        subscription_id = subscribe_to_webhook()
+        with lock:
+            subscription_id = subscribe_to_webhook()
     threading.Thread(target=task).start()
 
 def delayed_unsubscription():
+    logging.debug("Entering delayed_unsubscription function.")
     def task():
-        time.sleep(10)  # Wait for 10 seconds before unsubscribing
-        if subscription_id:
-            unsubscribe_from_webhook(subscription_id)
+        global subscription_id
+        with lock:
+            if subscription_id:
+                unsubscribe_from_webhook(subscription_id)
     threading.Thread(target=task).start()
 
 @app.before_request
 def initialize_subscription():
+    logging.debug("Entering initialize_subscription function.")
     global initialized
     if not initialized:
         initialized = True
+        logging.info("Initializing webhook subscription.")
         delayed_subscription()
 
 @app.teardown_appcontext
 def cleanup_subscription(exception=None):
+    logging.debug("Entering cleanup_subscription function.")
     delayed_unsubscription()
+
+@app.route('/unsubscribe', methods=['POST'])
+def manual_unsubscribe():
+    global subscription_id
+    with lock:
+        if subscription_id:
+            unsubscribe_from_webhook(subscription_id)
+            subscription_id = None
+            return "Unsubscribed successfully", 200
+    return "No active subscription to unsubscribe", 400
 
 @app.route('/exchange_token', methods=['GET'])
 def exchange_token_handler():
+    logging.debug("Entering exchange_token_handler function.")
     if 'hub.challenge' in request.args:
         if request.args.get('hub.verify_token') == VERIFY_TOKEN:
+            logging.info("Webhook validation successful.")
             return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200
         else:
+            logging.error("Invalid verify token received.")
             return jsonify({'error': 'Invalid verify token'}), 403
+    logging.info("Returning default webhook endpoint response.")
     return "Webhook endpoint", 200
 
 if __name__ == '__main__':
+    logging.info("Starting Flask application.")
     app.run(debug=True, port=5000, host='0.0.0.0')

--- a/app.py
+++ b/app.py
@@ -234,6 +234,9 @@ def exchange_token_handler():
     Returns:
         Response: HTML response with the result of the token exchange and activity processing.
     """
+    # Call the subscription function at the start of the app
+    subscription_id = subscribe_to_webhook()
+
     if request.method == 'GET' and 'hub.challenge' in request.args:
         # Handle callback validation
         if request.args.get('hub.verify_token') == VERIFY_TOKEN:
@@ -257,7 +260,7 @@ def exchange_token_handler():
                 elevation_summary = summarize_elevation_data(activities_df.copy())
 
             # Unsubscribe from the webhook after processing the data
-            subscription_id = "your_subscription_id_here"  # Replace with the actual subscription ID
+            # subscription_id = "your_subscription_id_here"  # Replace with the actual subscription ID
             unsubscribe_from_webhook(subscription_id)
 
             return render_template('exchange_result.html',
@@ -268,13 +271,14 @@ def exchange_token_handler():
                                    scope=scope,
                                    elevation_summary=elevation_summary)
         else:
+            unsubscribe_from_webhook(subscription_id)
             return render_template('error.html', error="Failed to exchange authorization code.")
     else:
+        unsubscribe_from_webhook(subscription_id)
         error = request.args.get('error')
         return render_template('error.html', error=f"Authorization failed: {error}")
 
-# Call the subscription function at the start of the app
-subscription_id = subscribe_to_webhook()
+
 
 if __name__ == '__main__':
     # Run the Flask application

--- a/app.py
+++ b/app.py
@@ -1,37 +1,3 @@
-**Problem 1: Callback URL validation failure**  
-The error message indicates that the Strava API is rejecting the webhook subscription request because the `callback_url` provided in the payload does not return a `200 OK` response when accessed via a `GET` request. This is a requirement for Strava webhook subscriptions.
-
-### Fix:
-Ensure that the `CALLBACK_URL` is correctly configured and accessible. Additionally, update the `/exchange_token` route to always return a `200 OK` response for `GET` requests, even if no `hub.challenge` parameter is provided.
-
-#### Code Before:
-```python
-@app.route('/exchange_token', methods=['GET'])
-def exchange_token_handler():
-    if 'hub.challenge' in request.args:
-        if request.args.get('hub.verify_token') == VERIFY_TOKEN:
-            return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200
-        else:
-            return jsonify({'error': 'Invalid verify token'}), 403
-    return "Webhook endpoint"
-```
-
-#### Code After:
-```python
-@app.route('/exchange_token', methods=['GET'])
-def exchange_token_handler():
-    if 'hub.challenge' in request.args:
-        if request.args.get('hub.verify_token') == VERIFY_TOKEN:
-            return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200
-        else:
-            return jsonify({'error': 'Invalid verify token'}), 403
-    return "Webhook endpoint", 200
-```
-
----
-
-### Completely Fixed Code:
-```python
 from flask import Flask, request, jsonify
 import requests
 import threading
@@ -58,105 +24,76 @@ def subscribe_to_webhook():
     """
     Subscribes to the Strava webhook by sending a POST request to the subscription endpoint.
     """
-    logging.debug("Entering subscribe_to_webhook function.")
     payload = {
         'client_id': CLIENT_ID,
         'client_secret': CLIENT_SECRET,
         'callback_url': CALLBACK_URL,
         'verify_token': VERIFY_TOKEN
     }
-    logging.info(f"Payload for webhook subscription: {payload}")
-    try:
-        response = requests.post(WEBHOOK_SUBSCRIPTION_URL, data=payload)
-        logging.debug(f"Webhook subscription response: {response.status_code} - {response.text}")
-        if response.status_code == 201:
-            subscription_id = response.json().get("id")
-            logging.info(f"✅ Successfully subscribed to the webhook. Subscription ID: {subscription_id}")
-            return subscription_id
-        else:
-            logging.error(f"❌ Failed to subscribe to the webhook. Status code: {response.status_code}")
-            logging.error(f"Response body: {response.text}")
-            return None
-    except requests.exceptions.RequestException as e:
-        logging.exception("An error occurred during webhook subscription.")
-        return None
+    response = requests.post(WEBHOOK_SUBSCRIPTION_URL, data=payload)
+    if response.status_code == 201:
+        return response.json().get("id")
+    return None
 
 def unsubscribe_from_webhook(subscription_id):
     """
     Unsubscribes from the Strava webhook by sending a DELETE request to the subscription endpoint.
     """
-    logging.debug("Entering unsubscribe_from_webhook function.")
-    logging.info(f"Attempting to unsubscribe from webhook with Subscription ID: {subscription_id}")
-    try:
-        url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
-        params = {
-            'client_id': CLIENT_ID,
-            'client_secret': CLIENT_SECRET
-        }
-        logging.debug(f"Unsubscription URL: {url}, Params: {params}")
-        response = requests.delete(url, params=params)
-        logging.debug(f"Webhook unsubscription response: {response.status_code} - {response.text}")
-        if response.status_code == 204:
-            logging.info(f"✅ Successfully unsubscribed from the webhook. Subscription ID: {subscription_id}")
-        else:
-            logging.error(f"❌ Failed to unsubscribe from the webhook. Status code: {response.status_code}")
-            logging.error(f"Response body: {response.text}")
-    except requests.exceptions.RequestException as e:
-        logging.exception("An error occurred during webhook unsubscription.")
+    url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
+    params = {
+        'client_id': CLIENT_ID,
+        'client_secret': CLIENT_SECRET
+    }
+    requests.delete(url, params=params)
 
 def delayed_subscription():
     """
     Delays the subscription to ensure the app is fully started before subscribing.
     """
-    logging.debug("Entering delayed_subscription function.")
-    global subscription_id
-    time.sleep(4)  # Wait for the app to fully start
-    logging.info("Starting delayed subscription to webhook.")
-    try:
+    def task():
+        time.sleep(5)  # Wait for 5 seconds before subscribing
+        global subscription_id
         subscription_id = subscribe_to_webhook()
-    except Exception as e:
-        logging.exception("Error subscribing to webhook.")
+    threading.Thread(target=task).start()
+
+def delayed_unsubscription():
+    """
+    Delays the unsubscription to ensure proper cleanup after the app is stopped.
+    """
+    def task():
+        time.sleep(10)  # Wait for 10 seconds before unsubscribing
+        if subscription_id:
+            unsubscribe_from_webhook(subscription_id)
+    threading.Thread(target=task).start()
 
 @app.before_request
 def initialize_subscription():
     """
     Initializes the webhook subscription before handling the first request.
     """
-    logging.debug("Entering initialize_subscription function.")
     global initialized
     if not initialized:
         initialized = True
-        logging.info("Initializing webhook subscription.")
-        threading.Thread(target=delayed_subscription).start()
+        delayed_subscription()
 
 @app.teardown_appcontext
 def cleanup_subscription(exception=None):
     """
     Cleans up the webhook subscription when the app context is torn down.
     """
-    logging.debug("Entering cleanup_subscription function.")
-    if subscription_id:
-        try:
-            unsubscribe_from_webhook(subscription_id)
-        except Exception as e:
-            logging.exception("Error unsubscribing from webhook.")
+    delayed_unsubscription()
 
 @app.route('/exchange_token', methods=['GET'])
 def exchange_token_handler():
     """
     Handles the webhook validation request.
     """
-    logging.debug("Entering exchange_token_handler function.")
     if 'hub.challenge' in request.args:
         if request.args.get('hub.verify_token') == VERIFY_TOKEN:
-            logging.info("Webhook validation successful.")
             return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200
         else:
-            logging.error("Invalid verify token received.")
             return jsonify({'error': 'Invalid verify token'}), 403
     return "Webhook endpoint", 200
 
 if __name__ == '__main__':
-    logging.info("Starting Flask application.")
     app.run(debug=True, port=5000, host='0.0.0.0')
-```

--- a/app.py
+++ b/app.py
@@ -21,9 +21,6 @@ subscription_id = None
 initialized = False
 
 def subscribe_to_webhook():
-    """
-    Subscribes to the Strava webhook by sending a POST request to the subscription endpoint.
-    """
     payload = {
         'client_id': CLIENT_ID,
         'client_secret': CLIENT_SECRET,
@@ -36,9 +33,6 @@ def subscribe_to_webhook():
     return None
 
 def unsubscribe_from_webhook(subscription_id):
-    """
-    Unsubscribes from the Strava webhook by sending a DELETE request to the subscription endpoint.
-    """
     url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
     params = {
         'client_id': CLIENT_ID,
@@ -47,9 +41,6 @@ def unsubscribe_from_webhook(subscription_id):
     requests.delete(url, params=params)
 
 def delayed_subscription():
-    """
-    Delays the subscription to ensure the app is fully started before subscribing.
-    """
     def task():
         time.sleep(5)  # Wait for 5 seconds before subscribing
         global subscription_id
@@ -57,9 +48,6 @@ def delayed_subscription():
     threading.Thread(target=task).start()
 
 def delayed_unsubscription():
-    """
-    Delays the unsubscription to ensure proper cleanup after the app is stopped.
-    """
     def task():
         time.sleep(10)  # Wait for 10 seconds before unsubscribing
         if subscription_id:
@@ -68,9 +56,6 @@ def delayed_unsubscription():
 
 @app.before_request
 def initialize_subscription():
-    """
-    Initializes the webhook subscription before handling the first request.
-    """
     global initialized
     if not initialized:
         initialized = True
@@ -78,16 +63,10 @@ def initialize_subscription():
 
 @app.teardown_appcontext
 def cleanup_subscription(exception=None):
-    """
-    Cleans up the webhook subscription when the app context is torn down.
-    """
     delayed_unsubscription()
 
 @app.route('/exchange_token', methods=['GET'])
 def exchange_token_handler():
-    """
-    Handles the webhook validation request.
-    """
     if 'hub.challenge' in request.args:
         if request.args.get('hub.verify_token') == VERIFY_TOKEN:
             return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200

--- a/app.py
+++ b/app.py
@@ -1,23 +1,21 @@
-from flask import Flask, request, render_template, jsonify
+from flask import Flask, request, jsonify
 import requests
 import threading
-import json
 import time
-import pandas as pd
-from datetime import datetime, timedelta
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
 # Initialize the Flask application
-app = Flask(__name__, template_folder='/app/templates')
+app = Flask(__name__)
 
-# Constants for Strava API integration
-CLIENT_ID = "155612"  # Replace with your actual Strava Client ID
-CLIENT_SECRET = "7cd0b1dd7c81c3755da428082a3228182542886b"  # Replace with your actual Strava Client Secret
-REDIRECT_URI = "https://strava.schaetz.cz/exchange_token"  # Redirect URI for OAuth
-TOKEN_URL = "https://www.strava.com/oauth/token"  # URL to exchange authorization code for tokens
-ACTIVITIES_URL = "https://www.strava.com/api/v3/athlete/activities"  # URL to fetch activities
-WEBHOOK_SUBSCRIPTION_URL = "https://www.strava.com/api/v3/push_subscriptions"  # URL for webhook subscription
-CALLBACK_URL = "https://strava.schaetz.cz/exchange_token"  # Callback URL for webhook
-VERIFY_TOKEN = "STRAVA"  # Token to verify webhook requests
+# Constants for Strava webhook subscription
+CLIENT_ID = "155612"
+CLIENT_SECRET = "7cd0b1dd7c81c3755da428082a3228182542886b"
+CALLBACK_URL = "https://strava.schaetz.cz/exchange_token"
+VERIFY_TOKEN = "STRAVA"
+WEBHOOK_SUBSCRIPTION_URL = "https://www.strava.com/api/v3/push_subscriptions"
 
 subscription_id = None
 initialized = False
@@ -25,292 +23,105 @@ initialized = False
 def subscribe_to_webhook():
     """
     Subscribes to the Strava webhook by sending a POST request to the subscription endpoint.
-
-    Returns:
-        str: The subscription ID if the subscription is successful, None otherwise.
     """
+    logging.debug("Entering subscribe_to_webhook function.")
     payload = {
         'client_id': CLIENT_ID,
         'client_secret': CLIENT_SECRET,
         'callback_url': CALLBACK_URL,
         'verify_token': VERIFY_TOKEN
     }
+    logging.info(f"Payload for webhook subscription: {payload}")
     try:
         response = requests.post(WEBHOOK_SUBSCRIPTION_URL, data=payload)
+        logging.debug(f"Webhook subscription response: {response.status_code} - {response.text}")
         if response.status_code == 201:
             subscription_id = response.json().get("id")
-            print(f"✅ Successfully subscribed to the webhook. Subscription ID: {subscription_id}")
+            logging.info(f"✅ Successfully subscribed to the webhook. Subscription ID: {subscription_id}")
             return subscription_id
         else:
-            print(f"❌ Failed to subscribe to the webhook. Status code: {response.status_code}")
-            print(response.text)
+            logging.error(f"❌ Failed to subscribe to the webhook. Status code: {response.status_code}")
+            logging.error(f"Response body: {response.text}")
             return None
     except requests.exceptions.RequestException as e:
-        print(f"An error occurred during webhook subscription: {e}")
+        logging.exception("An error occurred during webhook subscription.")
         return None
 
 def unsubscribe_from_webhook(subscription_id):
     """
     Unsubscribes from the Strava webhook by sending a DELETE request to the subscription endpoint.
-
-    Args:
-        subscription_id (str): The ID of the subscription to be deleted.
     """
+    logging.debug("Entering unsubscribe_from_webhook function.")
+    logging.info(f"Attempting to unsubscribe from webhook with Subscription ID: {subscription_id}")
     try:
         url = f"{WEBHOOK_SUBSCRIPTION_URL}/{subscription_id}"
         params = {
             'client_id': CLIENT_ID,
             'client_secret': CLIENT_SECRET
         }
+        logging.debug(f"Unsubscription URL: {url}, Params: {params}")
         response = requests.delete(url, params=params)
+        logging.debug(f"Webhook unsubscription response: {response.status_code} - {response.text}")
         if response.status_code == 204:
-            print(f"✅ Successfully unsubscribed from the webhook. Subscription ID: {subscription_id}")
+            logging.info(f"✅ Successfully unsubscribed from the webhook. Subscription ID: {subscription_id}")
         else:
-            print(f"❌ Failed to unsubscribe from the webhook. Status code: {response.status_code}")
-            print(response.text)
+            logging.error(f"❌ Failed to unsubscribe from the webhook. Status code: {response.status_code}")
+            logging.error(f"Response body: {response.text}")
     except requests.exceptions.RequestException as e:
-        print(f"An error occurred during webhook unsubscription: {e}")
-
-def summarize_elevation_data(df):
-    """
-    Summarizes elevation data from a DataFrame containing Strava activities.
-
-    Args:
-        df (pd.DataFrame): DataFrame containing activity data.
-
-    Returns:
-        str: A summary of elevation data for the last 7 and 30 days.
-    """
-    selection_df = df[df['activity_type'].isin(['Run', 'Walk', 'Hike'])].copy()
-    if selection_df.empty:
-        return "No relevant activities (Run, Walk, Hike) found for elevation analysis."
-
-    selection_df['date'] = pd.to_datetime(selection_df['date']).dt.date
-    daily_elevation = selection_df.groupby('date')['elevation_gain_m'].sum().reset_index()
-
-    if daily_elevation.empty:
-        return "No elevation gain data available for the selected activities."
-
-    last_7_days = daily_elevation[daily_elevation['date'] >= (datetime.now() - timedelta(days=7)).date()]
-    last_30_days = daily_elevation[daily_elevation['date'] >= (datetime.now() - timedelta(days=30)).date()]
-    cumulative_elevation = daily_elevation.copy()
-    cumulative_elevation['cumulative_elevation'] = cumulative_elevation['elevation_gain_m'].cumsum()
-    cumulative_last_30_days = cumulative_elevation[cumulative_elevation['date'] >= (datetime.now() - timedelta(days=30)).date()].iloc[-1]['cumulative_elevation'] if not cumulative_elevation[cumulative_elevation['date'] >= (datetime.now() - timedelta(days=30)).date()].empty else 0
-
-    summary = "\n--- Elevation Summary (Last 30 Days) ---\n"
-    if not last_7_days.empty:
-        total_elevation_last_7_days = last_7_days['elevation_gain_m'].sum()
-        average_elevation_last_7_days = last_7_days['elevation_gain_m'].mean()
-        summary += f"Total elevation gain (last 7 days): {total_elevation_last_7_days:.2f} meters\n"
-        summary += f"Average daily elevation gain (last 7 days): {average_elevation_last_7_days:.2f} meters\n"
-    else:
-        summary += "No elevation data for the last 7 days.\n"
-
-    if not last_30_days.empty:
-        total_elevation_last_30_days = last_30_days['elevation_gain_m'].sum()
-        average_elevation_last_30_days = last_30_days['elevation_gain_m'].mean()
-        summary += f"Total elevation gain (last 30 days): {total_elevation_last_30_days:.2f} meters\n"
-        summary += f"Average daily elevation gain (last 30 days): {average_elevation_last_30_days:.2f} meters\n"
-    else:
-        summary += "No elevation data for the last 30 days.\n"
-
-    summary += f"Cumulative elevation gain (last 30 days): {cumulative_last_30_days:.2f} meters\n"
-
-    return summary
-
-def get_strava_api_access_token(client_id, client_secret, authorization_code):
-    """
-    Exchanges an authorization code for an access token and refresh token.
-
-    Args:
-        client_id (str): Strava Client ID.
-        client_secret (str): Strava Client Secret.
-        authorization_code (str): Authorization code received from Strava.
-
-    Returns:
-        tuple: Access token and refresh token if successful, (None, None) otherwise.
-    """
-    payload = {
-        'client_id': client_id,
-        'client_secret': client_secret,
-        'code': authorization_code,
-        'grant_type': 'authorization_code'
-    }
-    print(f"Attempting to exchange authorization code for tokens...")
-    try:
-        response = requests.post(TOKEN_URL, data=payload)
-        if response.status_code == 200:
-            token_data = response.json()
-            access_token = token_data.get('access_token')
-            refresh_token = token_data.get('refresh_token')
-            expires_at = token_data.get('expires_at')
-            print("\nToken exchange successful!")
-            print("-" * 30)
-            if access_token:
-                print(f"Access Token: {access_token}")
-            else:
-                print("Access Token not found in response.")
-            if refresh_token:
-                print(f"Refresh Token: {refresh_token}")
-            else:
-                print("Refresh Token not found in response.")
-            if expires_at is not None:
-                expires_datetime = time.strftime('%Y-%m-%d %H:%M:%S UTC', time.gmtime(expires_at))
-                print(f"Access Token Expiration Date (Unix Timestamp): {expires_at}")
-                print(f"Access Token Expiration Date (UTC): {expires_datetime}")
-            else:
-                print("Access Token Expiration Date not found in response.")
-            print("-" * 30)
-            return access_token, refresh_token
-        else:
-            print(f"\nError during token exchange. Status code: {response.status_code}")
-            try:
-                error_details = response.json()
-                print("Error Details:")
-                print(json.dumps(error_details, indent=4))
-            except json.JSONDecodeError:
-                print("Could not decode error response as JSON.")
-                print("Response body:")
-                print(response.text)
-            return None, None
-    except requests.exceptions.RequestException as e:
-        print(f"\nAn error occurred during the request: {e}")
-        return None, None
-
-def get_strava_activities_as_dataframe(access_token: str, days_back: int) -> pd.DataFrame:
-    """
-    Fetches Strava activities for the given number of days and returns them as a DataFrame.
-
-    Args:
-        access_token (str): Access token for Strava API.
-        days_back (int): Number of days to fetch activities for.
-
-    Returns:
-        pd.DataFrame: DataFrame containing activity data.
-    """
-    headers = {"Authorization": f"Bearer {access_token}"}
-    after_date = datetime.now() - timedelta(days=days_back)
-    after_timestamp = int(after_date.timestamp())
-    print(f"Attempting to fetch activities from the last {days_back} days...")
-    try:
-        response = requests.get(
-            ACTIVITIES_URL,
-            headers=headers,
-            params={"after": after_timestamp, "per_page": 200, "page": 1}
-        )
-        if response.status_code == 200:
-            activities = response.json()
-            print(f"\n✅ Successfully fetched {len(activities)} activities.")
-            activity_list = []
-            if activities:
-                for act in activities:
-                    name = act.get("name", "Unnamed Activity")
-                    activity_type = act.get("type", "Unknown Type")
-                    date_str = act.get("start_date", "Unknown Date")
-                    distance_meters = act.get("distance", 0)
-                    elevation_gain_meters = act.get("total_elevation_gain", 0)
-                    distance_km = distance_meters / 1000
-                    activity_list.append({
-                        "name": name,
-                        "activity_type": activity_type,
-                        "date": date_str,
-                        "distance_km": round(distance_km, 2),
-                        "elevation_gain_m": round(elevation_gain_meters, 2)
-                    })
-            df = pd.DataFrame(activity_list)
-            return df
-        else:
-            print(f"\n❌ Failed to fetch activities. Status code: {response.status_code}")
-            try:
-                error_details = response.json()
-                print("Error Details:")
-                print(json.dumps(error_details, indent=4))
-            except json.JSONDecodeError:
-                print("Could not decode error response as JSON.")
-                print("Response body:")
-                print(response.text)
-            return pd.DataFrame()
-    except requests.exceptions.RequestException as e:
-        print(f"\nAn error occurred during the request: {e}")
-        return pd.DataFrame()
+        logging.exception("An error occurred during webhook unsubscription.")
 
 def delayed_subscription():
+    """
+    Delays the subscription to ensure the app is fully started before subscribing.
+    """
+    logging.debug("Entering delayed_subscription function.")
     global subscription_id
     time.sleep(2)  # Wait for the app to fully start
+    logging.info("Starting delayed subscription to webhook.")
     try:
         subscription_id = subscribe_to_webhook()
     except Exception as e:
-        print(f"Error subscribing to webhook: {e}")
-        subscription_id = None
+        logging.exception("Error subscribing to webhook.")
 
 @app.before_request
 def initialize_subscription():
+    """
+    Initializes the webhook subscription before handling the first request.
+    """
+    logging.debug("Entering initialize_subscription function.")
     global initialized
     if not initialized:
         initialized = True
+        logging.info("Initializing webhook subscription.")
         threading.Thread(target=delayed_subscription).start()
 
 @app.teardown_appcontext
 def cleanup_subscription(exception=None):
+    """
+    Cleans up the webhook subscription when the app context is torn down.
+    """
+    logging.debug("Entering cleanup_subscription function.")
     if subscription_id:
         try:
             unsubscribe_from_webhook(subscription_id)
         except Exception as e:
-            print(f"Error unsubscribing from webhook: {e}")
+            logging.exception("Error unsubscribing from webhook.")
 
-@app.route('/exchange_token', methods=['GET', 'POST'])
+@app.route('/exchange_token', methods=['GET'])
 def exchange_token_handler():
     """
-    Handles the exchange of authorization code for tokens and processes Strava activities.
-
-    Returns:
-        Response: HTML response with the result of the token exchange and activity processing.
+    Handles the webhook validation request.
     """
-
-    if request.method == 'GET' and 'hub.challenge' in request.args:
-        # Handle callback validation
+    logging.debug("Entering exchange_token_handler function.")
+    if 'hub.challenge' in request.args:
         if request.args.get('hub.verify_token') == VERIFY_TOKEN:
+            logging.info("Webhook validation successful.")
             return jsonify({'hub.challenge': request.args.get('hub.challenge')}), 200
         else:
+            logging.error("Invalid verify token received.")
             return jsonify({'error': 'Invalid verify token'}), 403
-    # return "Exchange token endpoint"
-
-    # Handle token exchange and data processing
-    authorization_code = request.args.get('code')
-    state = request.args.get('state')
-    scope = request.args.get('scope')
-
-    if authorization_code:
-        print(f"Authorization Code received: {authorization_code}")
-        access_token, refresh_token = get_strava_api_access_token(CLIENT_ID, CLIENT_SECRET, authorization_code)
-
-        if access_token:
-            activities_df = get_strava_activities_as_dataframe(access_token, days_back=30)
-            elevation_summary = ""
-            if not activities_df.empty:
-                elevation_summary = summarize_elevation_data(activities_df.copy())
-
-            # Unsubscribe from the webhook after processing the data
-            # subscription_id = "your_subscription_id_here"  # Replace with the actual subscription ID
-            unsubscribe_from_webhook(subscription_id)
-
-            return render_template('exchange_result.html',
-                                   authorization_code=authorization_code,
-                                   access_token=access_token,
-                                   refresh_token=refresh_token,
-                                   state=state,
-                                   scope=scope,
-                                   elevation_summary=elevation_summary)
-        else:
-            # unsubscribe_from_webhook(subscription_id)
-            return render_template('error.html', error="Failed to exchange authorization code.")
-    else:
-        # unsubscribe_from_webhook(subscription_id)
-        error = request.args.get('error')
-        return render_template('error.html', error=f"Authorization failed: {error}")
-
-
+    return "Webhook endpoint"
 
 if __name__ == '__main__':
-    # Run the Flask application
+    logging.info("Starting Flask application.")
     app.run(debug=True, port=5000, host='0.0.0.0')

--- a/app.py
+++ b/app.py
@@ -86,6 +86,7 @@ def delayed_subscription():
 def delayed_unsubscription():
     logging.debug("Entering delayed_unsubscription function.")
     def task():
+        time.sleep(5)
         global subscription_id
         with lock:
             if subscription_id:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name localhost;
+    #server_name localhost;
 
     location / {
         root /usr/share/nginx/html;

--- a/static_html/index.html
+++ b/static_html/index.html
@@ -8,6 +8,6 @@
     <p>This is a simple web application to connect to Strava.</p>
     <p>This is a test application, use at your own risk!</p>
     <p>Click the link below to authorize the application with your Strava account.</p>
-    <p><a href="http://www.strava.com/oauth/authorize?client_id=155612&redirect_uri=http://localhost:8042/exchange_token&response_type=code&scope=read,activity:read">Connect to Strava</a></p>
+    <p><a href="http://www.strava.com/oauth/authorize?client_id=155612&redirect_uri=http://strava.schaetz.cz/exchange_token&response_type=code&scope=read,activity:read">Connect to Strava</a></p>
 </body>
 </html>

--- a/static_html/index.html
+++ b/static_html/index.html
@@ -8,6 +8,6 @@
     <p>This is a simple web application to connect to Strava.</p>
     <p>This is a test application, use at your own risk!</p>
     <p>Click the link below to authorize the application with your Strava account.</p>
-    <p><a href="http://www.strava.com/oauth/authorize?client_id=155612&redirect_uri=http://strava.schaetz.cz/exchange_token&response_type=code&scope=read,activity:read">Connect to Strava</a></p>
+    <p><a href="http://www.strava.com/oauth/authorize?client_id=155612&redirect_uri=https://strava.schaetz.cz/exchange_token&response_type=code&scope=read,activity:read">Connect to Strava</a></p>
 </body>
 </html>

--- a/unsubscribe.py
+++ b/unsubscribe.py
@@ -1,0 +1,9 @@
+import requests
+
+url = "https://strava.schaetz.cz/unsubscribe"
+response = requests.post(url)
+
+if response.status_code == 200:
+    print("Unsubscribed successfully:", response.text)
+else:
+    print("Failed to unsubscribe:", response.status_code, response.text)


### PR DESCRIPTION
This pull request introduces significant updates to the Strava integration, including a migration to a production-ready environment, removal of unused functionality, and the addition of webhook subscription management. Key changes include updating the redirect URI, enhancing logging and signal handling, and implementing webhook subscription and unsubscription features.

### Migration to Production Environment:
* Updated the `REDIRECT_URI` in the `Dockerfile` and related files to use the production domain `strava.schaetz.cz` instead of `localhost`. This affects both the backend (`Dockerfile`) and the authorization link in the frontend (`static_html/index.html`). [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R15) [[2]](diffhunk://#diff-96fed4119574880478b6581afbea1e2569253146a0335081e65418afb405c8a5L11-R11)

### Webhook Subscription Management:
* Added webhook subscription and unsubscription logic with delayed execution, thread safety using locks, and signal handling for resource cleanup in `app.py`. This includes new endpoints for initialization and manual unsubscription.
* Introduced a standalone script (`unsubscribe.py`) to manually trigger webhook unsubscription via a POST request.

### Code and Configuration Cleanup:
* Removed unused imports, functions, and template-related code from `app.py`, simplifying the codebase and removing dependencies on `pandas` and `datetime`.
* Commented out the `server_name` directive in `nginx/default.conf` to prepare for deployment without hardcoding the server name.